### PR TITLE
Fix warning message produced by PublishSymbols task in CI pipeline.

### DIFF
--- a/pipelines/datastandardizer-ci-build-pipeline.yml
+++ b/pipelines/datastandardizer-ci-build-pipeline.yml
@@ -602,9 +602,9 @@ stages:
             #SymbolsFolder: '$(Build.SourcesDirectory)' # string. Path to symbols folder. Default: $(Build.SourcesDirectory).
             SearchPattern: 'src/**/bin/**/$(BuildConfiguration)/**/*.pdb' # string. Required. Search pattern. Default: **/bin/**/*.pdb.
             #Manifest: # string. Manifest. 
-            #IndexSources: true # boolean. Index sources. Default: true.
-            PublishSymbols: false # boolean. Publish symbols. Default: true.
-            # SymbolServerType: # 'TeamServices' | 'FileShare'. Required when PublishSymbols = true. Symbol server type. 
+            IndexSources: false  # boolean. Index sources. Default: true. # Disable indexing since GitHub is unsupported 
+            PublishSymbols: true # boolean. Publish symbols. Default: true.
+            SymbolServerType: 'TeamServices'  # Or 'FileShare'. Required when PublishSymbols = true. Symbol server type. 
             #SymbolsPath: # string. Optional. Use when PublishSymbols = true && SymbolServerType = FileShare. Path to publish symbols. 
             #CompressSymbols: false # boolean. Optional. Use when SymbolServerType = FileShare. Compress symbols. Default: false.
             #SymbolExpirationInDays: '36530' # string. Optional. Use when PublishSymbols = true && SymbolServerType = TeamServices. Symbol Expiration (in days). Default: 36530.

--- a/src/DataStandardizer.BCP47/DataStandardizer.BCP47.csproj
+++ b/src/DataStandardizer.BCP47/DataStandardizer.BCP47.csproj
@@ -59,6 +59,13 @@ Supports use of IETF BCP 47 language tags as defined by RFC 5646.</Description>
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\DataStandardizer.ISO15924\DataStandardizer.ISO15924.csproj" />
     <ProjectReference Include="..\DataStandardizer.ISO3166\DataStandardizer.ISO3166.csproj" />
     <ProjectReference Include="..\DataStandardizer.ISO639\DataStandardizer.ISO639.csproj" />

--- a/src/DataStandardizer.Core/DataStandardizer.Core.csproj
+++ b/src/DataStandardizer.Core/DataStandardizer.Core.csproj
@@ -52,4 +52,11 @@ Common types used to implement standards in the other packages.</Description>
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/DataStandardizer.ISO15924/DataStandardizer.ISO15924.csproj
+++ b/src/DataStandardizer.ISO15924/DataStandardizer.ISO15924.csproj
@@ -58,6 +58,13 @@ Supports use of ISO 15924, "Codes for the representation of names of scripts".</
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
       <ProjectReference Include="..\DataStandardizer.Core\DataStandardizer.Core.csproj" />
     </ItemGroup>
     

--- a/src/DataStandardizer.ISO3166/DataStandardizer.ISO3166.csproj
+++ b/src/DataStandardizer.ISO3166/DataStandardizer.ISO3166.csproj
@@ -61,6 +61,13 @@ Supports use of ISO 3166, "Codes for the representation of names of countries an
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\DataStandardizer.Core\DataStandardizer.Core.csproj" />
   </ItemGroup>
 

--- a/src/DataStandardizer.ISO4217/DataStandardizer.ISO4217.csproj
+++ b/src/DataStandardizer.ISO4217/DataStandardizer.ISO4217.csproj
@@ -58,6 +58,13 @@ Supports use of ISO 4217, "Codes for the representation of currencies and funds"
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\DataStandardizer.Core\DataStandardizer.Core.csproj" />
   </ItemGroup>
 

--- a/src/DataStandardizer.ISO639/DataStandardizer.ISO639.csproj
+++ b/src/DataStandardizer.ISO639/DataStandardizer.ISO639.csproj
@@ -57,6 +57,13 @@ Supports use of ISO 639, "Codes for the representation of names of languages" pa
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\DataStandardizer.Core\DataStandardizer.Core.csproj" />
   </ItemGroup>
 

--- a/src/DataStandardizer.UNM49/DataStandardizer.UNM49.csproj
+++ b/src/DataStandardizer.UNM49/DataStandardizer.UNM49.csproj
@@ -58,6 +58,13 @@ Supports use of UN M49 or the "Standard Country or Area Codes for Statistical Us
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\DataStandardizer.Core\DataStandardizer.Core.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Change `SearchPattern` parameter on `PublishSymbols` task to use correct file specification.