### PR TITLE
Apply package versioning to all projects in the solution for CI build pipeline.

### DIFF
--- a/pipelines/datastandardizer-ci-build-pipeline.yml
+++ b/pipelines/datastandardizer-ci-build-pipeline.yml
@@ -925,20 +925,8 @@ stages:
                   $projectPath = Join-Path -Path "$(Build.SourcesDirectory)" -ChildPath $packageInfo.packageSourcePath
                   Write-Host "##vso[task.setvariable variable=packageProjectPath]$projectPath"
                 displayName: "[${{packageName}}] Set version arguments"
-                condition: |
-                  and
-                  (
-                    succeeded(), 
-                    or(containsValue(split(variables.publicationRequiredPackageNames, ','), '${{packageName}}'), and(gt(length(coalesce(variables['changedPackageNames'], '')), 0), containsValue(split(variables['changedPackageNames'], ','), '${{packageName}}')))
-                  )                
               - task: VersionDotNetCoreAssemblies@3
                 displayName: "[${{ packageName }}] Apply package version numbers"
-                condition: |
-                  and
-                  (
-                    succeeded(), 
-                    or(containsValue(split(variables.publicationRequiredPackageNames, ','), '${{packageName}}'), and(gt(length(coalesce(variables['changedPackageNames'], '')), 0), containsValue(split(variables['changedPackageNames'], ','), '${{packageName}}')))
-                  )                
                 inputs:
                   Path: $(packageProjectPath)
                   VersionNumber: "$(majorNumber).$(minorNumber).$(patchNumber)-preview.$(previewNumber)"


### PR DESCRIPTION
Remove conditions from CI pipeline tasks that were preventing the application of package versions to .csproj files.

- Remove condition from "Set version arguments" task.
- Remove condition from "Apply package version numbers" task.