### PR TITLE
feat: Enhance CI pipeline with improved package versioning and new parameters

### DIFF
--- a/pipelines/datastandardizer-release-build-pipeline.yml
+++ b/pipelines/datastandardizer-release-build-pipeline.yml
@@ -66,6 +66,14 @@ parameters:
     - None
     - Build
     - Publication
+  - name: requirePackageDataStandardizerMoney
+    displayName: 'Force DataStandardizer.Money package'
+    type: string
+    default: None
+    values:
+    - None
+    - Build
+    - Publication
   - name: requirePackageDataStandardizerUnM49
     displayName: 'Force DataStandardizer.UNM49 package'
     type: string
@@ -120,6 +128,7 @@ variables:
       requirePackageDataStandardizerIso3166: ${{ parameters.requirePackageDataStandardizerIso3166 }}
       requirePackageDataStandardizerIso4217: ${{ parameters.requirePackageDataStandardizerIso4217 }}
       requirePackageDataStandardizerIso639: ${{ parameters.requirePackageDataStandardizerIso639 }}
+      requirePackageDataStandardizerMoney: ${{ parameters.requirePackageDataStandardizerMoney }}
       requirePackageDataStandardizerUnM49: ${{ parameters.requirePackageDataStandardizerUnM49 }}
 
 stages:
@@ -878,7 +887,8 @@ stages:
                       $patchNumber = $packageNewVersionNumberInfo.PackageVersion.Build
                       $previewNumber = $packageNewVersionNumberInfo.PackageVersion.Revision
 
-                      Write-Information "Using new version number $($packageNewVersionNumberInfo.PackageVersion.ToString()) for package ${{ packageName }}." -InformationAction Continue
+                      $versionDisplayText = @($majorNumber, $minorNumber, $patchNumber, $previewNumber) -join '.'
+                      Write-Information "Using new version number $versionDisplayText for package ${{ packageName }}." -InformationAction Continue
                   }
                   elseif ($null -ne $packageCurrentVersionNumberInfo) {
                       $majorNumber = $packageCurrentVersionNumberInfo.PackageVersion.Major
@@ -886,7 +896,8 @@ stages:
                       $patchNumber = $packageCurrentVersionNumberInfo.PackageVersion.Build
                       $previewNumber = $packageCurrentVersionNumberInfo.PackageVersion.Revision
 
-                      Write-Information "Using current version number $($packageCurrentVersionNumberInfo.PackageVersion.ToString()) for package ${{ packageName }}." -InformationAction Continue
+                      $versionDisplayText = @($majorNumber, $minorNumber, $patchNumber, $previewNumber) -join '.'
+                      Write-Information "Using current version number $versionDisplayText for package ${{ packageName }}." -InformationAction Continue
                   }
 
                   $packageVersion = "$($majorNumber).$($minorNumber).$($patchNumber)"
@@ -1013,7 +1024,38 @@ stages:
                   #ignoreLASTEXITCODE: false # boolean. Ignore $LASTEXITCODE. Default: false.
                   pwsh: true # boolean. Use PowerShell Core. Default: false.
                   #workingDirectory: # string. Working Directory. 
-                  #runScriptInSeparateScope: false # boolean. Run script in the separate scope. Default: false.                
+                  #runScriptInSeparateScope: false # boolean. Run script in the separate scope. Default: false.
+              - pwsh: |
+                  function ConvertFrom-Base64String {
+                      param (
+                          # Input.
+                          [Parameter(Mandatory, ValueFromPipeline)]
+                          [string]    $InputObject
+                      )
+
+                      process {
+                          $inputBytes = [System.Convert]::FromBase64String($InputObject)
+                          return [System.Text.Encoding]::UTF8.GetString($inputBytes)
+                      }
+                  }
+
+                  if (${{parameters.traceLevel}} -gt 0) {
+                      Set-PSDebug -Trace ${{parameters.traceLevel}}
+                  }
+
+                  $packageVersion = "$(packageVersions)" | 
+                  ConvertFrom-Base64String | 
+                  ConvertFrom-Json | 
+                  Where-Object -Property PackageName -EQ '${{packageName}}' | 
+                  Select-Object -First 1 -ExpandProperty PackageVersion
+                  Write-Host "##vso[task.setvariable variable=packageVersion]$packageVersion"
+                displayName: "[${{packageName}}] Set package version argument"
+                condition: |
+                  and
+                  (
+                    succeeded(), 
+                    or(containsValue(split(coalesce(variables.publicationRequiredPackageNames, ''), ','), '${{ packageName }}'), and(containsValue(split(coalesce(variables['changedPackageNames'], ''), ','), '${{ packageName }}'), eq(variables['isDevelopBranch'], 'true')))
+                  )                
               - task: DotNetCoreCLI@2
                 displayName: "[${{packageName}}] Create NuGet package"
                 condition: |
@@ -1057,7 +1099,7 @@ stages:
                   # requestedMajorVersion: 1  # Required  # The 'X' in version [X.Y.Z](http://semver.org/spec/v1.0.0.html)
                   # requestedMinorVersion: 0  # Required  # The 'Y' in version [X.Y.Z](http://semver.org/spec/v1.0.0.html)
                   # requestedPatchVersion: 0  # Required  # The 'Z' in version [X.Y.Z](http://semver.org/spec/v1.0.0.html)
-                  buildProperties: 'PackageReleaseNotes="$(releaseNotes)"' # Optional  # Specifies a list of token = value pairs, separated by semicolons, where each occurrence of token$ in the .nuspec file will be replaced with the given value. Values can be strings in quotation marks.
+                  buildProperties: 'PackageReleaseNotes="$(releaseNotes)";PackageVersion="$(packageVersion)"' # Optional  # Specifies a list of token = value pairs, separated by semicolons, where each occurrence of token$ in the .nuspec file will be replaced with the given value. Values can be strings in quotation marks.
                   verbosityPack: Normal # Options: '-', 'Quiet', 'Minimal', 'Normal', 'Detailed', 'Diagnostic' # Required  # Specifies the amount of detail displayed in the output.
                   # workingDirectory:   # Required when command != restore && command != push && command != pack  # Current working directory where the script is run. Empty is the root of the repo (build) or artifacts (release), which is $(System.DefaultWorkingDirectory). The project search pattern is **NOT** relative to working directory.
               - task: PowerShell@2


### PR DESCRIPTION
- Added `requirePackageDataStandardizerMoney` parameter to allow forcing the build or publication of the `DataStandardizer.Money` package.
- Updated pipeline variables to include the new `requirePackageDataStandardizerMoney` parameter.
- Improved version display logic by constructing `versionDisplayText` using concatenation of version components (`major`, `minor`, `patch`, `preview`).
- Introduced a new PowerShell step to decode and extract package version information from base64-encoded JSON.
- Updated `DotNetCoreCLI` task to include `PackageVersion` in `buildProperties` for better control over NuGet package metadata.
- Enhanced conditional logic for package versioning and publication to handle `isDevelopBranch` and changed package names more effectively.
- Added a utility function `ConvertFrom-Base64String` for decoding base64 strings in the pipeline.
- Improved logging and debugging options with support for `traceLevel` parameter.