### PR TITLE
ci: Update release build pipeline to include DataStandardizer.Chronology

### DIFF
--- a/pipelines/datastandardizer-release-build-pipeline.yml
+++ b/pipelines/datastandardizer-release-build-pipeline.yml
@@ -34,6 +34,14 @@ parameters:
     - None
     - Build
     - Publication
+  - name: requirePackageDataStandardizerChronology
+    displayName: 'Force DataStandardizer.Chronology package'
+    type: string
+    default: None
+    values:
+    - None
+    - Build
+    - Publication
   - name: requirePackageDataStandardizerIso15924
     displayName: 'Force DataStandardizer.ISO15924 package'
     type: string
@@ -124,6 +132,7 @@ variables:
     parameters:
       requirePackageDataStandardizerCore: ${{ parameters.requirePackageDataStandardizerCore }}
       requirePackageDataStandardizerBcp47: ${{ parameters.requirePackageDataStandardizerBcp47 }}
+      requirePackageDataStandardizerChronology: ${{ parameters.requirePackageDataStandardizerChronology }}
       requirePackageDataStandardizerIso15924: ${{ parameters.requirePackageDataStandardizerIso15924 }}
       requirePackageDataStandardizerIso3166: ${{ parameters.requirePackageDataStandardizerIso3166 }}
       requirePackageDataStandardizerIso4217: ${{ parameters.requirePackageDataStandardizerIso4217 }}


### PR DESCRIPTION
- Added a new parameter `requirePackageDataStandardizerChronology` to the release build pipeline.
- Enabled support for forcing the build or publication of the `DataStandardizer.Chronology` package.
- Updated variable mappings to include the new parameter. [AB#4293](https://solobyte.visualstudio.com/e60c6c5b-e7d1-4e3e-bc68-14798bf709a1/_workitems/edit/4293)