### PR TITLE
ci: Add support for forcing DataStandardizer.File package build and publication

### DIFF
--- a/pipelines/datastandardizer-release-build-pipeline.yml
+++ b/pipelines/datastandardizer-release-build-pipeline.yml
@@ -42,6 +42,14 @@ parameters:
     - None
     - Build
     - Publication
+  - name: requirePackageDataStandardizerFile
+    displayName: 'Force DataStandardizer.File package'
+    type: string
+    default: None
+    values:
+    - None
+    - Build
+    - Publication
   - name: requirePackageDataStandardizerIso15924
     displayName: 'Force DataStandardizer.ISO15924 package'
     type: string
@@ -133,6 +141,7 @@ variables:
       requirePackageDataStandardizerCore: ${{ parameters.requirePackageDataStandardizerCore }}
       requirePackageDataStandardizerBcp47: ${{ parameters.requirePackageDataStandardizerBcp47 }}
       requirePackageDataStandardizerChronology: ${{ parameters.requirePackageDataStandardizerChronology }}
+      requirePackageDataStandardizerFile: ${{ parameters.requirePackageDataStandardizerFile }}
       requirePackageDataStandardizerIso15924: ${{ parameters.requirePackageDataStandardizerIso15924 }}
       requirePackageDataStandardizerIso3166: ${{ parameters.requirePackageDataStandardizerIso3166 }}
       requirePackageDataStandardizerIso4217: ${{ parameters.requirePackageDataStandardizerIso4217 }}


### PR DESCRIPTION
ci: Add support for forcing DataStandardizer.File package build and publication
- Introduced a new pipeline parameter `requirePackageDataStandardizerFile` in `datastandardizer-release-build-pipeline.yml`.
- The parameter allows specifying actions (`None`, `Build`, or `Publication`) for the `DataStandardizer.File` package.
- Updated variable mappings to include the new parameter for consistent pipeline behavior.
[AB#4343](https://dev.azure.com/solobyte/e60c6c5b-e7d1-4e3e-bc68-14798bf709a1/_workitems/edit/4343)
[skip ci]