### PR TITLE
Updated project files to disable source revision inclusion in informational version

### DIFF
--- a/src/DataStandardizer.File.CSV/DataStandardizer.File.CSV.csproj
+++ b/src/DataStandardizer.File.CSV/DataStandardizer.File.CSV.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard1.3;netstandard2.0;net8.0</TargetFrameworks>
     <CheckNotRecommendedTargetFramework>false</CheckNotRecommendedTargetFramework>
     <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>

--- a/src/DataStandardizer.File/DataStandardizer.File.csproj
+++ b/src/DataStandardizer.File/DataStandardizer.File.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard1.3;netstandard2.0;net8.0</TargetFrameworks>
     <CheckNotRecommendedTargetFramework>false</CheckNotRecommendedTargetFramework>
     <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Authors>matthew25187</Authors>
     <Product>Data Standardizer</Product>
     <Description>Data Standardizer provides implementations of various internationally recognised standards in data processing, covering topics ranging from languages to currencies and geographical entities. With strongly-typed enumerations for each standard (where applicable) or other targeted data types, you can represent these elements in your code such that errors with invalid values are minimised.

--- a/src/DataStandardizer.Geography/DataStandardizer.Geography.csproj
+++ b/src/DataStandardizer.Geography/DataStandardizer.Geography.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard1.0;netstandard2.0;net8.0</TargetFrameworks>
     <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <CheckNotRecommendedTargetFramework>false</CheckNotRecommendedTargetFramework>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>


### PR DESCRIPTION
Updated project files to disable source revision inclusion in informational version
- Modified `IncludeSourceRevisionInInformationalVersion` property in the following projects:
  - `DataStandardizer.File.CSV`
  - `DataStandardizer.File`
  - `DataStandardizer.Geography`
- Set the property to `false` to exclude source revision information from the assembly's informational version.
This change ensures consistent versioning without including source revision details.