### PR TITLE
Refactor version handling in pipeline scripts and templates.

### DIFF
--- a/build/datastandardizer-ci-build-pipeline.yml
+++ b/build/datastandardizer-ci-build-pipeline.yml
@@ -658,7 +658,7 @@ stages:
                   ConvertFrom-Base64String | 
                   ConvertFrom-Json | 
                   Where-Object -Property PackageName -EQ -Value '${{packageName}}'
-                  Write-Host "##vso[task.setvariable variable=packageVersionArg]$($packageVersions.PackageProductionVersionString)"
+                  Write-Host "##vso[task.setvariable variable=packageVersionArg]$($packageVersions.PackageProductionVersionSemVer)"
                 displayName: "[${{packageName}}] Set package version argument"
                 condition: |
                   and
@@ -894,7 +894,7 @@ stages:
                       Write-Error 'Package versions not found for ${{packageName}}'
                   }
 
-                  [version]$productionPackageVersion = $packageVersions.PackageProductionVersion
+                  [version]$productionPackageVersion = $packageVersions.PackageProductionVersionDisplay
                   $message = "CI preview build $productionPackageVersion for package ${{packageName}}"
 
                   $tagName = "v$productionPackageVersion-${{packageName}}"

--- a/build/scripts/DeclareOptionalVersionNumbers.ps1
+++ b/build/scripts/DeclareOptionalVersionNumbers.ps1
@@ -39,23 +39,30 @@ $productionRevisionNumber = [System.Math]::Max($nextPackageVersion.Revision, 1)
 if ($env:BUILD_SOURCEBRANCH -eq 'refs/heads/master') {
     $productionRevisionNumber = 0
 }
-[version]$productionPackageVersion = ($productionMajorNumber, $productionMinorNumber, $productionBuildNumber, $productionRevisionNumber -join '.')
+[version]$productionPackageVersion = $productionMajorNumber, $productionMinorNumber, $productionBuildNumber, $productionRevisionNumber -join '.'
 $packageVersions.PackageProductionVersion = $productionPackageVersion.ToString()
 
 Write-Information "Production package version number will be $productionPackageVersion."
 
-$productionPackageVersionString = $productionPackageVersion.Major, $productionPackageVersion.Minor, $productionPackageVersion.Build -join '.'
+[version]$productionPackageVersionDisplay = $productionPackageVersion.Revision -eq 0 `
+    ?$productionPackageVersion.Major, $productionPackageVersion.Minor, $productionPackageVersion.Build -join '.' `
+    :$productionPackageVersion
+$packageVersions.PackageProductionVersionDisplay = $productionPackageVersionDisplay.ToString()
+
+Write-Information "Production package version number (display) will be $productionPackageVersionDisplay."
+
+$productionPackageVersionSemVer = $productionPackageVersion.Major, $productionPackageVersion.Minor, $productionPackageVersion.Build -join '.'
 if ($productionPackageVersion.Revision -gt 0) {
-    $productionPackageVersionString += "-$($packageVersions.PackageNextPrereleaseLabel).$($productionPackageVersion.Revision)"
+    $productionPackageVersionSemVer += "-$($packageVersions.PackageNextPrereleaseLabel).$($productionPackageVersion.Revision)"
 }
-$packageVersions.PackageProductionVersionString = $productionPackageVersionString
+$packageVersions.PackageProductionVersionSemVer = $productionPackageVersionSemVer
 $packageVersions.PackageProductionPrereleaseLabel = $packageVersions.PackageNextPrereleaseLabel
 
-Write-Information "Production package version will be $productionPackageVersionString."
+Write-Information "Production package version will be $productionPackageVersionSemVer."
 
 # Calculate post-production package version number.
 $postProductionNumbers = $productionPackageVersion.Major, $productionPackageVersion.Minor, $productionPackageVersion.Build, $productionPackageVersion.Revision
-$incrementFromIndex = $postProductionNumbers.Count - 1 # default to incrementing the preview number
+$incrementFromIndex = $postProductionNumbers.Count - 1 # default to incrementing the prerelease number
 if ($env:BUILD_SOURCEBRANCH -eq 'refs/heads/master') {
     $incrementFromIndex = 1 # increment minor number
 }
@@ -68,7 +75,7 @@ for ($versionPartIndex = $incrementFromIndex; $versionPartIndex -lt $postProduct
     }
 }
 
-[version]$postProductionPackageVersion = ($postProductionNumbers[0], $postProductionNumbers[1], $postProductionNumbers[2], $postProductionNumbers[3] -join '.')
+[version]$postProductionPackageVersion = $postProductionNumbers[0], $postProductionNumbers[1], $postProductionNumbers[2], $postProductionNumbers[3] -join '.'
 $packageVersions | Add-Member -MemberType NoteProperty -Name 'PackagePostProductionVersion' -Value $postProductionPackageVersion.ToString()
 Write-Information "Post-production package version number will be $postProductionPackageVersion."
 
@@ -78,11 +85,11 @@ $packageVersions.AssemblyProductionFileVersion = $productionAssemblyFileVersion.
 Write-Information "Production assembly file version number will be $productionAssemblyFileVersion."
 
 $productionAssemblyVersionRevision = [System.Convert]::ToInt32([datetime]::UtcNow.TimeOfDay.TotalSeconds / 2)
-[version]$productionAssemblyVersion = "$($productionPackageVersion.Major).$($productionPackageVersion.Minor).$($productionPackageVersion.Build).$productionAssemblyVersionRevision"
+[version]$productionAssemblyVersion = $productionPackageVersion.Major, $productionPackageVersion.Minor, $productionPackageVersion.Build, $productionAssemblyVersionRevision -join '.'
 $packageVersions.AssemblyProductionVersion = $productionAssemblyVersion.ToString()
 Write-Information "Production assembly version number will be $productionAssemblyVersion."
 
-[version]$productionAssemblyInformationalVersion = "$($productionPackageVersion.Major).$($productionPackageVersion.Minor)"
+[version]$productionAssemblyInformationalVersion = $productionPackageVersion.Major, $productionPackageVersion.Minor -join '.'
 $packageVersions.AssemblyProductionInformationalVersion = $productionAssemblyInformationalVersion.ToString()
 Write-Information "Production assembly informational version number will be $productionAssemblyInformationalVersion."
 

--- a/build/scripts/DeclareRequiredVersionNumbers.ps1
+++ b/build/scripts/DeclareRequiredVersionNumbers.ps1
@@ -62,19 +62,23 @@ $variableGroupVersionNumbers = $packageVersions |
 Where-Object { $_.Name.StartsWith('stable') -and $_.Name.EndsWith('number') } |
 Sort-Object -Property Name |
 Select-Object -ExpandProperty Value
-[version]$stablePackageVersion = ($variableGroupVersionNumbers[0], $variableGroupVersionNumbers[1], $variableGroupVersionNumbers[2] -join '.')
+[version]$stablePackageVersion = $variableGroupVersionNumbers[0], $variableGroupVersionNumbers[1], $variableGroupVersionNumbers[2] -join '.'
 
 # Fetch current package version number.
 $variableGroupVersionNumbers = $packageVersions |
 Where-Object { $_.Name.StartsWith('current') -and $_.Name.EndsWith('number') } |
 Sort-Object -Property Name |
 Select-Object -ExpandProperty Value
-[version] $currentPackageVersion = ($variableGroupVersionNumbers[0], $variableGroupVersionNumbers[1], $variableGroupVersionNumbers[2], $variableGroupVersionNumbers[3] -join '.')
+[version] $currentPackageVersion = $variableGroupVersionNumbers[0], $variableGroupVersionNumbers[1], $variableGroupVersionNumbers[2], $variableGroupVersionNumbers[3] -join '.'
 $currentPackagePrereleaseLabel = $packageVersions | Where-Object -Property Name -EQ -Value 'current-prerelease-label' | Select-Object -ExpandProperty Value
 
-$currentPackageVersionString = $currentPackageVersion.Major, $currentPackageVersion.Minor, $currentPackageVersion.Build -join '.'
+[version]$currentPackageVersionDisplay = $currentPackageVersion.Revision -eq 0 `
+    ?$currentPackageVersion.Major, $currentPackageVersion.Minor, $currentPackageVersion.Build -join '.' `
+    :$currentPackageVersion
+
+$currentPackageVersionSemVer = $currentPackageVersion.Major, $currentPackageVersion.Minor, $currentPackageVersion.Build -join '.'
 if ($currentPackageVersion.Revision -gt 0) {
-    $currentPackageVersionString += "-$currentPackagePrereleaseLabel.$($currentPackageVersion.Revision)"
+    $currentPackageVersionSemVer += "-$currentPackagePrereleaseLabel.$($currentPackageVersion.Revision)"
 }
 
 # Fetch next package version number.
@@ -82,13 +86,13 @@ $variableGroupVersionNumbers = $packageVersions |
 Where-Object { $_.Name.StartsWith('next') -and $_.Name.EndsWith('number') } |
 Sort-Object -Property Name |
 Select-Object -ExpandProperty Value
-[version] $nextPackageVersion = ($variableGroupVersionNumbers[0], $variableGroupVersionNumbers[1], $variableGroupVersionNumbers[2], $variableGroupVersionNumbers[3] -join '.')
+[version] $nextPackageVersion = $variableGroupVersionNumbers[0], $variableGroupVersionNumbers[1], $variableGroupVersionNumbers[2], $variableGroupVersionNumbers[3] -join '.'
 $nextPackagePrereleaseLabel = $packageVersions | Where-Object -Property Name -EQ -Value 'next-prerelease-label' | Select-Object -ExpandProperty Value
 
 # Fetch current version numbers from assembly.
 [version]$currentAssemblyVersion = $null; [version]$currentFileVersion = $null; [version]$currentInformationalVersion = $null
 
-nuget install $PackageName -DependencyVersion Ignore -DirectDownload -ExcludeVersion -NoHttpCache -NonInteractive -OutputDirectory $env:AGENT_TEMPDIRECTORY -PackageSaveMode nupkg -PreRelease -Source 'https://pkgs.dev.azure.com/solobyte/DataStandardizer/_packaging/DataStandardizer/nuget/v3/index.json' -Source 'https://api.nuget.org/v3/index.json' -Verbosity detailed -Version $currentPackageVersionString 2>&1 | Write-Host
+nuget install $PackageName -DependencyVersion Ignore -DirectDownload -ExcludeVersion -NoHttpCache -NonInteractive -OutputDirectory $env:AGENT_TEMPDIRECTORY -PackageSaveMode nupkg -PreRelease -Source 'https://pkgs.dev.azure.com/solobyte/DataStandardizer/_packaging/DataStandardizer/nuget/v3/index.json' -Source 'https://api.nuget.org/v3/index.json' -Verbosity detailed -Version $currentPackageVersionSemVer 2>&1 | Write-Host
 
 [string]$currentPackageFolderPath
 $currentPackageArchivePath = Get-ChildItem -Path $env:AGENT_TEMPDIRECTORY -Filter "$PackageName.nupkg" -Recurse | Select-Object -ExpandProperty FullName
@@ -141,7 +145,8 @@ $packageVersions = [PSCustomObject]@{
     PackageNextVersion                     = $nextPackageVersion.ToString()
     PackageNextPrereleaseLabel             = $nextPackagePrereleaseLabel
     PackageProductionVersion               = $currentPackageVersion.ToString()
-    PackageProductionVersionString         = $currentPackageVersionString
+    PackageProductionVersionDisplay        = $currentPackageVersionDisplay.ToString()
+    PackageProductionVersionSemVer         = $currentPackageVersionSemVer
     PackageProductionPrereleaseLabel       = $currentPackagePrereleaseLabel
     AssemblyProductionVersion              = ${currentAssemblyVersion}?.ToString()
     AssemblyProductionFileVersion          = ${currentFileVersion}?.ToString()
@@ -150,7 +155,8 @@ $packageVersions = [PSCustomObject]@{
 
 Write-Information "Stable package version number is $stablePackageVersion."
 Write-Information "Current package version number is $currentPackageVersion."
-Write-Information "Current package version is $currentPackageVersionString."
+Write-Information "Current package version number (display) is $currentPackageVersionDisplay."
+Write-Information "Current package version is $currentPackageVersionSemVer."
 Write-Information "Current package pre-release label is $currentPackagePrereleaseLabel."
 Write-Information "Next package version number will be $nextPackageVersion."
 Write-Information "Next package pre-release label is $nextPackagePrereleaseLabel."

--- a/build/scripts/UpdatePackageMetadata.ps1
+++ b/build/scripts/UpdatePackageMetadata.ps1
@@ -191,7 +191,7 @@ foreach ($dependencyNode in $dependencyNodes) {
         continue
     }
 
-    $dependencyPackageVersion = $dependencyPackageVersions.PackageProductionVersionString
+    $dependencyPackageVersion = $dependencyPackageVersions.PackageProductionVersionSemVer
     if (([version]$updatingPackageVersions.PackageProductionVersion).Revision -eq 0 -and ([version]$dependencyPackageVersions.PackageProductionVersion).Revision -gt 0 -and ([version]$dependencyPackageVersions.PackageStableVersion) -gt $emptyVersion) {
         $dependencyPackageVersion = $dependencyPackageVersions.PackageStableVersion
     }


### PR DESCRIPTION
Refactor version handling in pipeline scripts and templates.
- **Pipeline Templates**:
  - Updated `datastandardizer-ci-build-pipeline.yml` to use `PackageProductionVersionSemVer` instead of `PackageProductionVersionString` for setting package version arguments.
  - Adjusted logic for production package version handling to use `PackageProductionVersionDisplay`.
- **PowerShell Scripts**:
  - Enhanced `DeclareOptionalVersionNumbers.ps1`:
    - Introduced `PackageProductionVersionDisplay` for display-friendly version formatting.
    - Added `PackageProductionVersionSemVer` for semantic versioning.
    - Improved handling of production and post-production version numbers.
  - Updated `DeclareRequiredVersionNumbers.ps1`:
    - Added `PackageProductionVersionDisplay` and `PackageProductionVersionSemVer` for better version representation.
    - Replaced `PackageProductionVersionString` with `PackageProductionVersionSemVer` in NuGet installation commands.
  - Refactored `UpdatePackageMetadata.ps1` to use `PackageProductionVersionSemVer` for dependency version updates.
These changes improve consistency, readability, and adherence to semantic versioning across the build and release pipelines.
[AB#4373](https://dev.azure.com/solobyte/e60c6c5b-e7d1-4e3e-bc68-14798bf709a1/_workitems/edit/4373)