### PR TITLE
Update version handling in `datastandardizer-release-build-pipeline.yml`.

### DIFF
--- a/build/datastandardizer-release-build-pipeline.yml
+++ b/build/datastandardizer-release-build-pipeline.yml
@@ -613,7 +613,7 @@ stages:
                   ConvertFrom-Base64String | 
                   ConvertFrom-Json | 
                   Where-Object -Property PackageName -EQ -Value '${{packageName}}'
-                  Write-Host "##vso[task.setvariable variable=packageVersionArg]$($packageVersions.PackageProductionVersionString)"
+                  Write-Host "##vso[task.setvariable variable=packageVersionArg]$($packageVersions.PackageProductionVersionSemVer)"
                 displayName: "[${{packageName}}] Set package version argument"
                 condition: |
                   and
@@ -844,7 +844,7 @@ stages:
                       Write-Error 'Package versions not found for ${{packageName}}'
                   }
 
-                  [version]$productionPackageVersion = $packageVersions.PackageProductionVersion
+                  [version]$productionPackageVersion = $packageVersions.PackageProductionVersionDisplay
                   $message = "Release build $productionPackageVersion for package ${{packageName}}"
 
                   $tagName = "v$productionPackageVersion-${{packageName}}"


### PR DESCRIPTION
Update version handling in `datastandardizer-release-build-pipeline.yml`.
- Replaced `PackageProductionVersionString` with `PackageProductionVersionSemVer` for setting the `packageVersionArg` variable.
- Updated version assignment to use `PackageProductionVersionDisplay` instead of `PackageProductionVersion`.
- Improved consistency and clarity in handling package version variables.
[AB#4373](https://dev.azure.com/solobyte/e60c6c5b-e7d1-4e3e-bc68-14798bf709a1/_workitems/edit/4373)