### PR TITLE
Enable PowerShell Core in the Data Standardizer release build pipeline

### DIFF
--- a/build/datastandardizer-release-build-pipeline.yml
+++ b/build/datastandardizer-release-build-pipeline.yml
@@ -354,7 +354,7 @@ stages:
               #failOnStderr: false # boolean. Fail on Standard Error. Default: false.
               #showWarnings: false # boolean. Show warnings as Azure DevOps warnings. Default: false.
               #ignoreLASTEXITCODE: false # boolean. Ignore $LASTEXITCODE. Default: false.
-              #pwsh: false # boolean. Use PowerShell Core. Default: false.
+              pwsh: true # boolean. Use PowerShell Core. Default: false.
               #workingDirectory: # string. Working Directory. 
               #runScriptInSeparateScope: false # boolean. Run script in the separate scope. Default: false.            
         # PowerShell v2


### PR DESCRIPTION
Enable PowerShell Core in the Data Standardizer release build pipeline
- Updated the `datastandardizer-release-build-pipeline.yml` file to enable the use of PowerShell Core (`pwsh: true`).
[AB#4373](https://dev.azure.com/solobyte/e60c6c5b-e7d1-4e3e-bc68-14798bf709a1/_workitems/edit/4373)