### PR TITLE
Fix release notes generation to scope and sanitise per package

### DIFF
--- a/build/scripts/SetReleaseNotesArgument.ps1
+++ b/build/scripts/SetReleaseNotesArgument.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 3.0
+#Requires -Version 7.0
 
 param (
     # Package name.
@@ -6,7 +6,7 @@ param (
     [ValidateNotNullOrEmpty()]
     [string]    $PackageName,
 
-    # Release Note separation.
+    # Split a single commit message into separate release notes on ';' boundaries.
     [Parameter()]
     [bool]  $IsReleaseNoteSeparationRequired = $false,
 
@@ -21,52 +21,101 @@ if (0 -lt $TraceLevel) {
     Set-PSDebug -Trace $TraceLevel
 }
 
-# Find the most recent tag for the package.
+# Resolve the package's source folder so release notes can be scoped to commits that
+# actually touched this package (rather than every change across the repository).
+$packageInfo = $env:PACKAGEINFOS | ConvertFrom-Json | Where-Object -Property packageName -EQ -Value $PackageName
+if ($null -eq $packageInfo) {
+    Write-Error "No package information found for $PackageName."
+    exit
+}
+$packageSourcePath = $packageInfo.packageSourcePath
+
+# Find the most recent tag for the package that is an ancestor of the build commit.
+# `--merged` (not `--no-contains`) restricts the candidates to tags reachable from the
+# build commit, so the chosen baseline is genuinely the previous tag on this history.
+$escapedPackageName = [regex]::Escape($PackageName)
 $packageMatchPattern = "v*$PackageName"
-$tagsOutput = & git tag --list $packageMatchPattern --sort=-version:refname --no-contains $env:BUILD_SOURCEVERSION
-# $isMasterBranch = "$(Build.SourceBranch)" -eq 'refs/heads/master'
-$tagMatchPattern = ($env:BUILD_SOURCEBRANCH -eq 'refs/heads/master') ? "^v\d+\.\d+\.\d+-$PackageName$" : "^v\d+\.\d+\.\d+\.\d+-$PackageName$"
-[string]$latestTagName = $tagsOutput -split '\r?\n' | Select-String -Pattern $tagMatchPattern -Raw | Select-Object -First 1 | Out-String -Stream
+$tagsOutput = & git tag --list $packageMatchPattern --sort=-version:refname --merged $env:BUILD_SOURCEVERSION
+# On master the package is promoted to a 3-part release version, so notes accumulate from
+# the previous release tag; otherwise (pre-release) they accumulate from the previous 4-part tag.
+$tagMatchPattern = ($env:BUILD_SOURCEBRANCH -eq 'refs/heads/master') ? "^v\d+\.\d+\.\d+-$escapedPackageName$" : "^v\d+\.\d+\.\d+\.\d+-$escapedPackageName$"
+[string]$latestTagName = $tagsOutput -split '\r?\n' | Select-String -Pattern $tagMatchPattern -Raw | Select-Object -First 1
 
 # Find the repository object preceding the source commit.
 [string]$previousCommitObject
 if (-not [string]::IsNullOrWhiteSpace($latestTagName)) {
-    $previousCommitObject = "tags/$latestTagName"
+    $previousCommitObject = "tags/$($latestTagName.Trim())"
 }
 else {
-    $previousCommitObject = & git log --format="%H" --no-abbrev-commit | tail -1
+    $previousCommitObject = & git log --format="%H" --no-abbrev-commit | Select-Object -Last 1
 }
-$revisionListOutput = Invoke-Expression "git rev-list $previousCommitObject..$env:BUILD_SOURCEVERSION --no-commit-header --format=%s"
 
-Write-Information "Using commit messages between $previousCommitObject and $env:BUILD_SOURCEVERSION."
+# Collect the commit subjects between the baseline and the build commit, excluding merge
+# commits and scoping to the package's source folder.
+$revisionRange = "$previousCommitObject..$env:BUILD_SOURCEVERSION"
+$revisionListOutput = & git rev-list $revisionRange --no-merges --reverse --no-commit-header --format=%s -- $packageSourcePath
 
-# Compose the release notes.
+Write-Information "Using commit messages between $previousCommitObject and $env:BUILD_SOURCEVERSION scoped to $packageSourcePath."
+
+# Patterns to scrub from commit messages before they become release notes.
 [string[]]$sanitiseTags = @('[skip ci]', '[ci skip]', 'skip-checks: true', 'skip-checks:true', '[skip azurepipelines]', '[azurepipelines skip]', '[skip azpipelines]', '[azpipelines skip]', '[skip azp]', '[azp skip]', '***NO_CI***')
 $sanitisePattern = [string]::Join('|', [System.Linq.Enumerable]::Select[string, string]($sanitiseTags, [System.Func[string, string]] { param($tag)[regex]::Escape($tag) }))
 
+# Tidy a raw commit subject into a release note: drop CI directives and ticket/PR references,
+# normalise whitespace, and ensure terminating punctuation. Returns $null when nothing remains.
+function Format-ReleaseNote {
+    param (
+        [string]    $Message,
+        [string]    $SanitisePattern
+    )
+
+    $note = $Message -replace $SanitisePattern, [string]::Empty
+    # Remove a trailing parenthesised PR reference (e.g. " (#87)") added by squash merges.
+    $note = $note -replace '\s*\(#\d+\)', [string]::Empty
+    # Remove any remaining bare ticket/PR references (e.g. "#123").
+    $note = $note -replace '#\d+', [string]::Empty
+    # Collapse whitespace left behind by the removals.
+    $note = ($note -replace '\s{2,}', ' ').Trim()
+
+    if ([string]::IsNullOrWhiteSpace($note)) {
+        return $null
+    }
+    # Append a full stop unless the note already ends in terminating punctuation
+    # (full stop, exclamation/question mark, or an ellipsis), ignoring any trailing
+    # closing quote (straight or curly) or bracket.
+    $closingChars = [char[]]@('"', "'", ')', ']', [char]0x2019, [char]0x201D)
+    $terminators = [char[]]@('.', '!', '?', [char]0x2026)
+    $trimmed = $note.TrimEnd($closingChars)
+    if ($trimmed.Length -eq 0 -or $terminators -notcontains $trimmed[-1]) {
+        $note += '.'
+    }
+    return $note
+}
+
+# Compose the release notes.
 $releaseNotesBuilder = [System.Text.StringBuilder]::new()
-$revisionListOutput -split '\r?\n' | Select-String -Pattern '#\d+' -Raw | Out-String -Stream | ForEach-Object {
-    $sanitisedCommitMessage = $_ -replace $sanitisePattern, [string]::Empty
-    if ($IsReleaseNoteSeparationRequired) {
-        $ticketReference = $sanitisedCommitMessage | Select-String -Pattern '(#\d+.*?)(?=\s)' | Select-Object -ExpandProperty Matches | Select-Object -Property Value -First 1 | Format-Table -HideTableHeaders | Out-String -NoNewline
-        $sanitisedCommitMessage -split ';' | ForEach-Object { 
-            $releaseNote = $_.Trim()
-            if (-not $releaseNote.EndsWith('.')) {
-                $releaseNote += '.'
+$revisionListOutput -split '\r?\n' |
+    Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+    ForEach-Object {
+        $commitMessage = $_
+        $noteSources = $IsReleaseNoteSeparationRequired ? ($commitMessage -split ';') : @($commitMessage)
+        foreach ($noteSource in $noteSources) {
+            $releaseNote = Format-ReleaseNote -Message $noteSource -SanitisePattern $sanitisePattern
+            if ($null -ne $releaseNote) {
+                [void]$releaseNotesBuilder.AppendLine("*`t$releaseNote")
             }
-            if ($releaseNote -notlike "$ticketReference*") {
-                $releaseNote = ($ticketReference + ' ' + $releaseNote)
-            }
-            [void]$releaseNotesBuilder.AppendLine("*`t$releaseNote")
         }
     }
-    else {
-        [void]$releaseNotesBuilder.AppendLine("*`t$sanitisedCommitMessage")
-    }
-}
 $releaseNotes = $releaseNotesBuilder.ToString().TrimEnd()
 $releaseNotes
 
-# Output release notes to pipeline variable.
-$encodedReleaseNotes = $releaseNotes | ConvertTo-Base64String
-Write-Host "##vso[task.setvariable variable=releaseNotesArg]$encodedReleaseNotes"
+# Output release notes to pipeline variable. When no relevant notes were produced, clear the
+# variable so UpdatePackageMetadata removes any stale releaseNotes element from the .nuspec.
+if ([string]::IsNullOrWhiteSpace($releaseNotes)) {
+    Write-Information "No relevant commit messages found for $PackageName; release notes will be cleared."
+    Write-Host "##vso[task.setvariable variable=releaseNotesArg]"
+}
+else {
+    $encodedReleaseNotes = $releaseNotes | ConvertTo-Base64String
+    Write-Host "##vso[task.setvariable variable=releaseNotesArg]$encodedReleaseNotes"
+}


### PR DESCRIPTION
@
## Problem

Release notes applied to NuGet package metadata contained information that did not apply to the specific package or version being published, and information that was not relevant (e.g. ticket/PR numbers and merge-commit noise). This deviated from the intent of deriving release notes from the commits between version tags for the package being built.

## Root causes (in `SetReleaseNotesArgument.ps1`)

- **No path scoping** — `git rev-list` collected every commit in the range for *every* package, so each package reported unrelated changes (pipeline/CI/docs/other packages).
- **Wrong baseline tag** — `--no-contains` could pick a tag that is not an ancestor of the build commit, giving the wrong/oversized commit range.
- **Merge commits not excluded** — no `--no-merges`.
- **Inverted reference handling** — commits were *filtered* to only those containing `#nn`, and the references were left in the text, rather than being *stripped*.
- **Massaging never ran** — the tidy-up branch was gated behind a flag the pipeline never sets.

## Changes

- Scope notes to the package source folder via a `git rev-list` pathspec (path resolved from `PACKAGEINFOS`), so each package only reports commits that touched it.
- Use `--merged` for the baseline tag (an ancestor of the build commit), consistent with `FindChangedPackages.ps1`.
- Add `--no-merges` to exclude merge commits.
- Strip ticket/PR references (parenthesised `(#nn)` and bare `#nn`) instead of filtering on them.
- Always sanitise (CI-tag scrub, whitespace collapse, terminating punctuation), independent of the separation flag; the punctuation check leaves existing terminators/ellipses and trailing quotes intact.
- Clear the `releaseNotesArg` variable when no relevant commits remain (so `UpdatePackageMetadata` removes any stale notes) rather than failing the mandatory Base64 conversion.
- Replace the non-native `tail -1` fallback with `Select-Object -Last 1`.

No pipeline YAML changes are required — the script resolves everything from variables already in scope.

## Verification

- Script parses cleanly (`Parser::ParseFile`), source is pure ASCII (no encoding fragility).
- Sanitisation and trailing-punctuation logic tested against representative commit subjects from this repo.
- Git-dependent behaviour (tag selection, path-scoped `rev-list`) exercises only inside the pipeline environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@