### PR TITLE
Synchronize the shared ITU E.164 parse expression cache

### DIFF
--- a/src/DataStandardizer.Communication/E164/ItuE164InternationalNumberStructureBase.cs
+++ b/src/DataStandardizer.Communication/E164/ItuE164InternationalNumberStructureBase.cs
@@ -20,6 +20,7 @@ namespace DataStandardizer.Communication.E164
         protected const string PatternWhiteSpaceCharacterClass = @"\p{Zs}\p{Cc}";
 
         private static readonly Dictionary<(Type, ItuE164InternationalNumberStyles), Regex> ParseExpressions = new Dictionary<(Type, ItuE164InternationalNumberStyles), Regex>();
+        private static readonly object ParseExpressionsLock = new object();
 
         protected internal ItuE164InternationalNumberStructureBase(ulong number)
         {
@@ -86,18 +87,26 @@ namespace DataStandardizer.Communication.E164
 
         protected static Regex GetParseExpression(Type discriminatorType, ItuE164InternationalNumberStyles numberStyles, Func<ItuE164InternationalNumberStyles, string> getParsePattern)
         {
-            if (!ParseExpressions.TryGetValue((discriminatorType, numberStyles), out var parseExpression))
+            // The cache is shared by every number structure type and is populated lazily from
+            // ItuE164InternationalNumber.Parse/TryParse, so unsynchronized access would let concurrent
+            // callers corrupt the Dictionary. A lock is used in preference to ConcurrentDictionary
+            // because the netstandard1.0 target does not offer one; contention is negligible, as the
+            // cache saturates after a handful of calls and every later call is a lookup under the lock.
+            lock (ParseExpressionsLock)
             {
-                var parseExpressionOptions = RegexOptions.Singleline;
+                if (!ParseExpressions.TryGetValue((discriminatorType, numberStyles), out var parseExpression))
+                {
+                    var parseExpressionOptions = RegexOptions.Singleline;
 #if NETSTANDARD1_3_OR_GREATER||NET
-                parseExpressionOptions |= RegexOptions.Compiled;
+                    parseExpressionOptions |= RegexOptions.Compiled;
 #endif
-                var parsePattern = getParsePattern(numberStyles);
-                parseExpression = new Regex(parsePattern, parseExpressionOptions);
-                ParseExpressions.Add((discriminatorType, numberStyles), parseExpression);
-            }
+                    var parsePattern = getParsePattern(numberStyles);
+                    parseExpression = new Regex(parsePattern, parseExpressionOptions);
+                    ParseExpressions.Add((discriminatorType, numberStyles), parseExpression);
+                }
 
-            return parseExpression;
+                return parseExpression;
+            }
         }
     }
 }

--- a/tests/DataStandardizer.Communication.Tests/E164/ItuE164InternationalNumberConcurrencyTests.cs
+++ b/tests/DataStandardizer.Communication.Tests/E164/ItuE164InternationalNumberConcurrencyTests.cs
@@ -1,0 +1,140 @@
+﻿using System.Collections;
+using System.Collections.Concurrent;
+using System.Reflection;
+using DataStandardizer.Communication.E164;
+using FluentAssertions;
+
+namespace DataStandardizer.Communication.Tests.E164
+{
+    /// <summary>
+    /// Regression tests covering concurrent access to the parse expression cache shared by every
+    /// ITU E.164 number structure type. Before the cache was synchronized, concurrent parsing could
+    /// throw from the unguarded <see cref="Dictionary{TKey,TValue}.Add"/>, return a torn value, or
+    /// spin forever on a corrupted bucket chain.
+    /// </summary>
+    public class ItuE164InternationalNumberConcurrencyTests
+    {
+        private const int ParallelCallCount = 32;
+
+        /// <summary>
+        /// A number that no structure type accepts, so that parsing it walks all five structures and
+        /// populates all five parse expression cache entries in a single call.
+        /// </summary>
+        private const string UnparsableNumber = "+0 999 9999";
+
+        private const string ValidNumberForGeographicArea = "+64 411 5550100";
+
+        private static readonly TimeSpan ParallelCallTimeout = TimeSpan.FromSeconds(30);
+
+        [Fact]
+        public void Parse_CalledConcurrentlyWithColdParseExpressionCache_ReturnsTheSameNumberOnEveryThread()
+        {
+            // arrange
+            var expectedResult = ItuE164InternationalNumber.Parse(ValidNumberForGeographicArea, ItuE164InternationalNumberStyles.Any).Number;
+            ResetParseExpressionCache();
+            var testResults = new ulong[ParallelCallCount];
+
+            // act
+            var testExceptions = RunInParallel(index => testResults[index] = ItuE164InternationalNumber.Parse(ValidNumberForGeographicArea, ItuE164InternationalNumberStyles.Any).Number);
+
+            // assert
+            testExceptions.Should().BeEmpty();
+            testResults.Should().AllBeEquivalentTo(expectedResult);
+        }
+
+        [Fact]
+        public void TryParse_CalledConcurrentlyWithColdParseExpressionCacheAndAnUnparsableNumber_ReturnsFalseWithoutThrowing()
+        {
+            // arrange
+            ItuE164InternationalNumber.TryParse(UnparsableNumber, ItuE164InternationalNumberStyles.Any, out _)
+                .Should().BeFalse("the test relies on a number that exercises every structure type's parse expression");
+            ResetParseExpressionCache();
+            var testResults = new bool[ParallelCallCount];
+
+            // act
+            var testExceptions = RunInParallel(index => testResults[index] = ItuE164InternationalNumber.TryParse(UnparsableNumber, ItuE164InternationalNumberStyles.Any, out _));
+
+            // assert
+            testExceptions.Should().BeEmpty();
+            testResults.Should().AllBeEquivalentTo(false);
+        }
+
+        [Fact]
+        public void Parse_CalledConcurrentlyWithColdParseExpressionCacheAcrossDistinctStyles_CachesOneExpressionPerStyle()
+        {
+            // arrange
+            var testStyles = new[]
+            {
+                ItuE164InternationalNumberStyles.None,
+                ItuE164InternationalNumberStyles.AllowInternationalPrefixSymbol,
+                ItuE164InternationalNumberStyles.AllowLeadingWhite,
+                ItuE164InternationalNumberStyles.AllowTrailingWhite,
+                ItuE164InternationalNumberStyles.AllowLeadingWhite | ItuE164InternationalNumberStyles.AllowTrailingWhite,
+                ItuE164InternationalNumberStyles.Any
+            };
+            ResetParseExpressionCache();
+
+            // act
+            var testExceptions = RunInParallel(index => ItuE164InternationalNumber.TryParse(UnparsableNumber, testStyles[index % testStyles.Length], out _));
+
+            // assert
+            testExceptions.Should().BeEmpty();
+            GetParseExpressionCache().Count.Should().Be(testStyles.Length * NumberStructureTypeCount, "each style should cache exactly one parse expression per structure type");
+        }
+
+        #region Private Methods
+
+        /// <summary>
+        /// Runs <paramref name="parseAction"/> on <see cref="ParallelCallCount"/> dedicated threads that
+        /// are released simultaneously, so that they contend for the cold parse expression cache.
+        /// </summary>
+        private static IReadOnlyCollection<Exception> RunInParallel(Action<int> parseAction)
+        {
+            var callBarrier = new Barrier(ParallelCallCount);
+            var callExceptions = new ConcurrentQueue<Exception>();
+            var callTasks = Enumerable.Range(0, ParallelCallCount)
+                .Select(index => Task.Factory.StartNew(
+                    () =>
+                    {
+                        callBarrier.SignalAndWait();
+                        try
+                        {
+                            parseAction(index);
+                        }
+                        catch (Exception exception)
+                        {
+                            callExceptions.Enqueue(exception);
+                        }
+                    },
+                    TaskCreationOptions.LongRunning))
+                .ToArray();
+
+            // A corrupted cache can leave a reader spinning on a cyclic bucket chain, so fail rather than hang.
+            Task.WaitAll(callTasks, ParallelCallTimeout).Should().BeTrue("parsing should not deadlock or spin on the shared parse expression cache");
+
+            return callExceptions;
+        }
+
+        private static int NumberStructureTypeCount => typeof(ItuE164InternationalNumberStructureBase).Assembly.GetTypes()
+            .Count(type => !type.GetTypeInfo().IsAbstract && typeof(ItuE164InternationalNumberStructureBase).IsAssignableFrom(type));
+
+        private static IDictionary GetParseExpressionCache()
+        {
+            var cacheField = typeof(ItuE164InternationalNumberStructureBase).GetField("ParseExpressions", BindingFlags.NonPublic | BindingFlags.Static);
+            cacheField.Should().NotBeNull("the parse expression cache is accessed by name");
+            return (IDictionary)cacheField!.GetValue(null)!;
+        }
+
+        private static void ResetParseExpressionCache()
+        {
+            var lockField = typeof(ItuE164InternationalNumberStructureBase).GetField("ParseExpressionsLock", BindingFlags.NonPublic | BindingFlags.Static);
+            lockField.Should().NotBeNull("the parse expression cache lock is accessed by name");
+            lock (lockField!.GetValue(null)!)
+            {
+                GetParseExpressionCache().Clear();
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Parsing an ITU E.164 number from more than one thread could throw, yield a wrong result, or spin forever. The parse expression cache in `ItuE164InternationalNumberStructureBase` is a `Dictionary` shared by every number structure type, and `GetParseExpression` read it and inserted into it without synchronization; `Dictionary` is documented as safe for concurrent readers only, any writer at all breaking that guarantee.

`readonly` on the field protects the reference, not the contents, so the declaration gave no protection against this.

## Exposure

`Parse` and `TryParse` try each of the five structure types in turn until one matches, so a single call performs up to five unsynchronized read and write cycles. The cache is coldest at startup, when a service is most likely to be serving several requests at once.

Three failure modes follow, in rough order of likelihood:

- Concurrent callers collide on the insertion and are given an `ArgumentException` reporting a duplicate key.
- A write racing a resize corrupts the bucket arrays, giving `IndexOutOfRangeException`, `NullReferenceException`, or a silently wrong lookup.
- A bucket chain becomes cyclic and a later reader loops forever, presenting as a hung thread at full CPU rather than as an exception.

This also escaped the contract of `TryParse`, which is documented never to throw. A caller guarding `Parse` against `FormatException` did not catch it either, both failures arriving from a dictionary rather than from parsing.

## Change

Guard the cache with a lock, so that the lookup and the insertion which follows it cannot be interleaved. A lock is used in preference to `ConcurrentDictionary` because the `netstandard1.0` target does not offer one, and contention is negligible: the cache saturates after a handful of calls and every call thereafter is a dictionary lookup taken under the lock.

## Tests

Adds `ItuE164InternationalNumberConcurrencyTests`, which resets the cache to cold and releases thirty-two threads at a barrier so that they contend for the same key. The tests assert that `Parse` agrees on every thread, that `TryParse` returns `false` without throwing, and that the cache holds exactly one expression per style per structure type. Waiting on the threads is bounded, so that the corruption which manifests as a spinning reader fails the test rather than hanging the suite.

The tests were confirmed to catch the defect rather than merely to pass: with the lock removed and the lock field retained so that the reflection still resolved, all three failed on three of three runs, each reporting `ArgumentException: An item with the same key has already been added. Key: (ItuE164InternationalNumberStructureForGeographicAreas, Any)`. One of the three failures arrived out of `TryParse`, confirming the contract violation above.

## Verification

- Builds clean across all four target frameworks (`netstandard1.0`, `netstandard2.0`, `net8.0`, `net10.0`), with no warnings; `lock` is available on `netstandard1.0`.
- `DataStandardizer.Communication.Tests`: 78,769 passed, 0 failed, 24 skipped (the pre-existing Groups and Trials skips).
- `DataStandardizer.Chronology.Tests`: 45 passed, 0 failed.

`DataStandardizer.Chronology` was audited alongside this and holds no shared mutable state. Two benign races were found and deliberately left alone: the lazy `_formatter` assignment on the shared `TelephonyInfo.InvariantTelephony` singleton, whose formatter has no fields at all, and the generated `Resources.resourceMan`. Neither can produce observable corruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

